### PR TITLE
fix(search-auto-complete.component.ts): fixed drop down stuck on hidden

### DIFF
--- a/src/app/components/shared/inputs/search-auto-complete/search-auto-complete.component.ts
+++ b/src/app/components/shared/inputs/search-auto-complete/search-auto-complete.component.ts
@@ -83,6 +83,9 @@ export class SearchAutoCompleteComponent<T extends object> {
 
   valueInputChange($event: HTMLInputElement) {
     const value = $event.value;
+
+    if (value === undefined) return;
+
     if (!value) {
       this.showIconOptionSelected = false;
       this.isDropDownHidden.set(true);


### PR DESCRIPTION
The dropdown of auto search input was getting stuck while user type
something. Now it fixed. It should act as normal :)